### PR TITLE
LineBasedFrameDecoder: document the possiblity of command smuggling

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/LineBasedFrameDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/LineBasedFrameDecoder.java
@@ -32,6 +32,10 @@ import java.util.List;
  * byte values for multibyte codepoint representations therefore fully supported by this implementation.
  * <p>
  * For a more general delimiter-based decoder, see {@link DelimiterBasedFrameDecoder}.
+ * <p>
+ * Users should be aware that used as is, the lenient approach on lone "\n" might result on a parser diffenrencial on line based protocols
+ * requiring the use of "\r\n" delimiters like SMTP and can result in attacks similar to SMTP smuggling (https://sec-consult.com/blog/detail/smtp-smuggling-spoofing-e-mails-worldwide/). 
+ * Validating afterward the end of line pattern can be a possible mitigation.
  */
 public class LineBasedFrameDecoder extends ByteToMessageDecoder {
 


### PR DESCRIPTION
A lenient approach regarding end of lines can result in a parser differential.

Example of such attacks: https://sec-consult.com/blog/detail/smtp-smuggling-spoofing-e-mails-worldwide/

As recommended in a private advisory we should document this and a possible mitigation in LineBasedFrameDecoder

Motivation:

Avoid new implementers of line based protocol to write vulnerable applications.

Modification:

Simple JavaDoc modification

